### PR TITLE
add edge case where FORTLINK couldn't be determined by CMake

### DIFF
--- a/Tools/CMake/AMReX_Defines.cmake
+++ b/Tools/CMake/AMReX_Defines.cmake
@@ -97,7 +97,8 @@ function ( set_amrex_defines )
 
       set( FORTLINK "" )
 
-      if ( FortranCInterface_GLOBAL_SUFFIX STREQUAL "" )
+      if ( (FortranCInterface_GLOBAL_SUFFIX STREQUAL "" ) AND NOT
+          (FortranCInterface_GLOBAL_CASE STREQUAL "") )
          set(FORTLINK "${FortranCInterface_GLOBAL_CASE}CASE" )
          message(STATUS "Fortran name mangling scheme: ${FORTLINK} (no append underscore)")
       elseif ( (FortranCInterface_GLOBAL_SUFFIX STREQUAL "_")  AND


### PR DESCRIPTION
I think you'll need this to trigger my edge case where CMake failed to determine FORTLINK -- in this particular edge case:
```
FortranCInterface_GLOBAL_PREFIX=''
FortranCInterface_GLOBAL_SUFFIX=''
FortranCInterface_GLOBAL_CASE=''
```